### PR TITLE
segment hashes are prefixed with numeric version

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -17,7 +17,7 @@ export const isValidUserUUID = (str) => {
 };
 
 export const isValidSegmentUUID = (str) => {
-  return /^([a-f0-9]{64}|[a-f0-9]{8}\-[a-f0-9]{4}\-[a-f0-9]{4}\-[a-f0-9]{4}\-[a-f0-9]{12})$/.test(
+  return /^([a-f0-9]{64,65}|[a-f0-9]{8}\-[a-f0-9]{4}\-[a-f0-9]{4}\-[a-f0-9]{4}\-[a-f0-9]{12})$/.test(
     str
   );
 };


### PR DESCRIPTION
currently, it will not accept v3 or v4 hashes since they are 65 characters long