### PR TITLE
force actionType to add POI

### DIFF
--- a/src/pages/LockCategories.svelte
+++ b/src/pages/LockCategories.svelte
@@ -37,7 +37,7 @@
       videoID = '';
       reason = '';
       categories = [];
-      actionTypes = [...actionTypeList];
+      actionTypes = [...actionTypeList, 'poi'];
     }
     if (result === 400) {
       status = STATUS.ERROR_INVALID;


### PR DESCRIPTION
currently poi_highlight can only be added when POI type is selected. Not worth adding a separate label just for it, and it should be filtered by the server